### PR TITLE
docs: add notice for wow-frontend redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Discussion Board
 
+**NOTE: Way of Work information (`wow-frontend`) is being migrated to the [Developer Portal](dhis2.github.io)**
+
+Please raise an [issue](https://github.com/dhis2/dhis2.github.io/issues) there if something is missing
+
+This repository has been renamed to `notes` to serve the purpose of recording decissions and discussions over time.
+
 ## Proposals / Discussion
 
 Create an issue in GitHub, it can be discussed in the issue, and then a

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Please raise an [issue](https://github.com/dhis2/dhis2.github.io/issues) there if something is missing
 
-This repository has been renamed to `notes` to serve the purpose of recording decissions and discussions over time.
+This repository has been renamed to `notes` to serve the purpose of recording decisions and discussions over time.
 
 ## Proposals / Discussion
 


### PR DESCRIPTION
This should help people who find this repository through straggling links to `wow-frontend` get to the right place and understand what moved.

**NB** Eventually, the same will likely be required for the `wow-backend` repository