### PR TITLE
docs: add play environment docs

### DIFF
--- a/gotchas/our-play-environments.md
+++ b/gotchas/our-play-environments.md
@@ -1,0 +1,9 @@
+## Overview
+
+We have several environments online for people to use for testing, debugging, etc.:
+
+* debug.dhis2.org is meant for devs
+* verify.dhis2.org is meant for QA team (i.e. please consider it out-of-bounds!)
+* empty.dhis2.org for testing with empty db (mainly for QA)
+
+The idea is that you administer the instances, creating as necessary then cleaning up after yourself! Logs go to an ELK-stack server (logs.dhis2.org)


### PR DESCRIPTION
Added the notes from https://dhis2.slack.com/archives/C0BP0RABF/p1566895743100300 here. Thought it'd be useful to have this info somewhere where it's discoverable, as on slack I'd lose track of it.

I think that this probably doesn't belong in the gotchas, but I'm not sure where else to put it. Let me know if there's a better place for it.

@dhis2/team-apps @Philip-Larsen-Donnelly 