### PR TITLE
docs: add styled-jsx ui-core gotcha

### DIFF
--- a/gotchas/styled-jsx-in-ui-core.md
+++ b/gotchas/styled-jsx-in-ui-core.md
@@ -1,0 +1,9 @@
+# Usage of styled-jsx in our ui-core library
+
+With styled-jsx, for our components in ui-core:
+
+- We try to target the element (e.g. https://github.com/dhis2/ui-core/blob/master/src/Button/styles.js#L6)
+- Sometimes we cannot do that, e.g. if we have nested div elements, then we use cx('root', className) and add the .root to the outermost div
+- We accept that styles may bleed into our components if the consumer is using global styles (https://github.com/dhis2/ui-core#how-to-avoid-a-global-style-rule-from-affecting-a-ui-core-component)
+- We guarantee that our components will never bleed out styles to other components
+- We use the className prop to allow overrides from a consumer, and we attach the className prop to the outermost element of our component

--- a/gotchas/styled-jsx-in-ui-core.md
+++ b/gotchas/styled-jsx-in-ui-core.md
@@ -3,7 +3,7 @@
 With styled-jsx, for our components in ui-core:
 
 - We try to target the element (e.g. https://github.com/dhis2/ui-core/blob/master/src/Button/styles.js#L6)
-- Sometimes we cannot do that, e.g. if we have nested div elements, then we use cx('root', className) and add the .root to the outermost div
+  - Sometimes we cannot do that, e.g. if we have nested div elements, then we use cx('root', className) and add the .root to the outermost div
 - We accept that styles may bleed into our components if the consumer is using global styles (https://github.com/dhis2/ui-core#how-to-avoid-a-global-style-rule-from-affecting-a-ui-core-component)
 - We guarantee that our components will never bleed out styles to other components
 - We use the className prop to allow overrides from a consumer, and we attach the className prop to the outermost element of our component


### PR DESCRIPTION
Adding something that wasn't clear to me about our styling approach in ui-core, for future reference. I can also imagine that this is more at home in the readme of ui-core btw. Depends on whether this advice applies to multiple codebases or not (ui-widgets, etc.).

TODO:

- [ ] Add info from https://github.com/dhis2/ui-core/pull/501#issue-327709259
- [ ] Add info from https://github.com/dhis2/ui-core/pull/501#issuecomment-541706551